### PR TITLE
SSH Public Key Fixes, Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ You can pass hosts via CLI arguments:
 lhp compile --host my-host-1 --host my-host-2 > /tmp/lhp-report.json
 ```
 
-This command connects to hosts in parallel. If any of the hosts cause
-an error, entire operation will fail. To ignore failed hosts, you can
-use `--stream` mode:
+This command connects to hosts sequentially and ignores problematic
+hosts in the output.
+
+To use parallel mode, use `--parallel` flag. In this case, if any of
+the hosts cause an error, entire operation will fail:
 
 ```sh
-lhp compile --stream --host my-host-1 --host my-host-2 | jq --slurp . > /tmp/lhp-report.json
+lhp compile --parallel --host my-host-1 --host my-host-2 > /tmp/lhp-report.json
 ```
 
 Alternatively, you can use a configuration file which has additional
@@ -112,10 +114,10 @@ individually on the command-line:
 lhp compile --config config.yaml > /tmp/lhp-report.json
 ```
 
-..., or:
+..., or mix with `--host` option:
 
 ```sh
-lhp compile --stream --config config.yaml | jq --slurp . > /tmp/lhp-report.json
+lhp compile --config config.yaml --host a-host --host b-host > /tmp/lhp-report.json
 ```
 
 Users can process/analyse the JSON output themselves or use [Website]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ follows:
 
 ```yaml
 ## config.yaml
+## List of known SSH public keys to be added to the report.
+##
+## These can be then used by external programs of lhp Web UI to
+## highlight if a host has an unknown authorized SSH public key.
+knownSshKeys:
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKq9bpy0IIfDnlgaTCQk0YhKyKFqInRjoqeIPlBuiFwS testing
+
+## List of hosts to patrol
 hosts:
   - ## Name of the host (required)
     name: somehost

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,11 @@
+## List of known SSH public keys to be added to the report.
+##
+## These can be then used by external programs of lhp Web UI to
+## highlight if a host has an unknown authorized SSH public key.
+knownSshKeys:
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKq9bpy0IIfDnlgaTCQk0YhKyKFqInRjoqeIPlBuiFwS testing
+
+## List of hosts to patrol
 hosts:
   - ## Name of the host (required)
     name: somehost

--- a/src/Lhp/Cli.hs
+++ b/src/Lhp/Cli.hs
@@ -69,7 +69,7 @@ commandCompile = OA.hsubparser (OA.command "compile" (OA.info parser infomod) <>
 -- | @compile@ CLI command program.
 doCompile :: Maybe FilePath -> [T.Text] -> Bool -> IO ExitCode
 doCompile cpath dests par = do
-  baseConfig <- maybe (pure (Config.Config [])) Config.readConfigFile cpath
+  baseConfig <- maybe (pure (Config.Config [] [])) Config.readConfigFile cpath
   let config =
         baseConfig
           { Config._configHosts = Config._configHosts baseConfig <> fmap _mkHost dests

--- a/src/Lhp/Config.hs
+++ b/src/Lhp/Config.hs
@@ -8,14 +8,16 @@ module Lhp.Config where
 
 import qualified Autodocodec as ADC
 import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 import GHC.Generics (Generic)
 import qualified Lhp.Types as Types
 
 
 -- | Data definition for application configuration.
-newtype Config = Config
-  { _configHosts :: [Types.Host]
+data Config = Config
+  { _configHosts :: ![Types.Host]
+  , _configKnownSshKeys :: ![T.Text]
   }
   deriving (Eq, Generic, Show)
   deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Config)
@@ -29,6 +31,7 @@ instance ADC.HasCodec Config where
         ADC.object "Config" $
           Config
             <$> ADC.optionalFieldWithDefault "hosts" [] "List of hosts." ADC..= _configHosts
+            <*> ADC.optionalFieldWithDefault "knownSshKeys" [] "List of hosts." ADC..= _configKnownSshKeys
 
 
 -- | Attempts to read a configuration file and return 'Config'.

--- a/src/Lhp/Types.hs
+++ b/src/Lhp/Types.hs
@@ -19,8 +19,9 @@ import GHC.Generics (Generic)
 
 
 -- | Data definition for host patrol report.
-newtype Report = Report
-  { _reportHosts :: [HostReport]
+data Report = Report
+  { _reportHosts :: ![HostReport]
+  , _reportKnownSshKeys :: ![SshPublicKey]
   }
   deriving (Eq, Generic, Show)
   deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Report)
@@ -34,6 +35,7 @@ instance ADC.HasCodec Report where
         ADC.object "Report" $
           Report
             <$> ADC.requiredField "hosts" "List of host reports." ADC..= _reportHosts
+            <*> ADC.requiredField "knownSshKeys" "List of known SSH public keys." ADC..= _reportKnownSshKeys
 
 
 -- * Host
@@ -72,7 +74,7 @@ data HostReport = HostReport
   , _hostReportKernel :: !Kernel
   , _hostReportDistribution :: !Distribution
   , _hostReportDockerContainers :: !(Maybe [DockerContainer])
-  , _hostReportSshAuthorizedKeys :: ![SshPublicKey]
+  , _hostReportAuthorizedSshKeys :: ![SshPublicKey]
   , _hostReportSystemdServices :: ![T.Text]
   , _hostReportSystemdTimers :: ![T.Text]
   }
@@ -93,7 +95,7 @@ instance ADC.HasCodec HostReport where
             <*> ADC.requiredField "kernel" "Kernel information." ADC..= _hostReportKernel
             <*> ADC.requiredField "distribution" "Distribution information." ADC..= _hostReportDistribution
             <*> ADC.requiredField "dockerContainers" "List of Docker containers if the host is a Docker host." ADC..= _hostReportDockerContainers
-            <*> ADC.requiredField "sshAuthorizedKeys" "List of SSH authorized keys found on host." ADC..= _hostReportSshAuthorizedKeys
+            <*> ADC.requiredField "authorizedSshKeys" "List of authorized SSH public keys found on host." ADC..= _hostReportAuthorizedSshKeys
             <*> ADC.requiredField "systemdServices" "List of systemd services found on host." ADC..= _hostReportSystemdServices
             <*> ADC.requiredField "systemdTimers" "List of systemd timers found on host." ADC..= _hostReportSystemdTimers
 

--- a/src/Lhp/Types.hs
+++ b/src/Lhp/Types.hs
@@ -8,6 +8,7 @@ module Lhp.Types where
 
 import qualified Autodocodec as ADC
 import qualified Data.Aeson as Aeson
+import Data.Int (Int32)
 import Data.Scientific (Scientific)
 import qualified Data.Text as T
 import qualified Data.Time as Time
@@ -120,7 +121,7 @@ instance ADC.HasCodec Cloud where
 
 -- | Data definition for host's rudimentary hardware information.
 data Hardware = Hardware
-  { _hardwareCpuCount :: !Int
+  { _hardwareCpuCount :: !Int32 -- :)
   , _hardwareRamTotal :: !Scientific
   , _hardwareDiskRoot :: !Scientific
   }

--- a/src/Lhp/Types.hs
+++ b/src/Lhp/Types.hs
@@ -51,7 +51,7 @@ data Report = Report
   , _reportKernel :: !Kernel
   , _reportDistribution :: !Distribution
   , _reportDockerContainers :: !(Maybe [DockerContainer])
-  , _reportSshAuthorizedKeys :: ![T.Text]
+  , _reportSshAuthorizedKeys :: ![SshPublicKey]
   , _reportSystemdServices :: ![T.Text]
   , _reportSystemdTimers :: ![T.Text]
   }
@@ -230,3 +230,32 @@ instance ADC.HasCodec DockerContainer where
             <*> ADC.requiredField "image" "Image the container is created from." ADC..= _dockerContainerImage
             <*> ADC.requiredField "created" "Date/time when the container is created at." ADC..= _dockerContainerCreated
             <*> ADC.requiredField "running" "Indicates if the container is running." ADC..= _dockerContainerRunning
+
+
+-- * SSH Public Key Information
+
+
+-- | Data definition for SSH public key information.
+data SshPublicKey = SshPublicKey
+  { _sshPublicKeyData :: !T.Text
+  , _sshPublicKeyType :: !T.Text
+  , _sshPublicKeyLength :: !Int32
+  , _sshPublicKeyComment :: !T.Text
+  , _sshPublicKeyFingerprint :: !T.Text
+  }
+  deriving (Eq, Generic, Show)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec SshPublicKey)
+
+
+instance ADC.HasCodec SshPublicKey where
+  codec =
+    _codec ADC.<?> "SSH Public Key Information"
+    where
+      _codec =
+        ADC.object "SshPublicKey" $
+          SshPublicKey
+            <$> ADC.requiredField "data" "Original information." ADC..= _sshPublicKeyData
+            <*> ADC.requiredField "type" "Type of the public key." ADC..= _sshPublicKeyType
+            <*> ADC.requiredField "length" "Length of the public key." ADC..= _sshPublicKeyLength
+            <*> ADC.requiredField "comment" "Comment on the public key." ADC..= _sshPublicKeyComment
+            <*> ADC.requiredField "fingerprint" "Fingerprint of the public key." ADC..= _sshPublicKeyFingerprint

--- a/src/Lhp/Types.hs
+++ b/src/Lhp/Types.hs
@@ -15,6 +15,27 @@ import qualified Data.Time as Time
 import GHC.Generics (Generic)
 
 
+-- * Report
+
+
+-- | Data definition for host patrol report.
+newtype Report = Report
+  { _reportHosts :: [HostReport]
+  }
+  deriving (Eq, Generic, Show)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Report)
+
+
+instance ADC.HasCodec Report where
+  codec =
+    _codec ADC.<?> "Host Patrol Report"
+    where
+      _codec =
+        ADC.object "Report" $
+          Report
+            <$> ADC.requiredField "hosts" "List of host reports." ADC..= _reportHosts
+
+
 -- * Host
 
 
@@ -40,41 +61,41 @@ instance ADC.HasCodec Host where
             <*> ADC.optionalFieldWithDefault "tags" [] "Arbitrary tags for the host." ADC..= _hostTags
 
 
--- * Report
+-- * Host Report
 
 
 -- | Data definition for host patrol report.
-data Report = Report
-  { _reportHost :: !Host
-  , _reportCloud :: !Cloud
-  , _reportHardware :: !Hardware
-  , _reportKernel :: !Kernel
-  , _reportDistribution :: !Distribution
-  , _reportDockerContainers :: !(Maybe [DockerContainer])
-  , _reportSshAuthorizedKeys :: ![SshPublicKey]
-  , _reportSystemdServices :: ![T.Text]
-  , _reportSystemdTimers :: ![T.Text]
+data HostReport = HostReport
+  { _hostReportHost :: !Host
+  , _hostReportCloud :: !Cloud
+  , _hostReportHardware :: !Hardware
+  , _hostReportKernel :: !Kernel
+  , _hostReportDistribution :: !Distribution
+  , _hostReportDockerContainers :: !(Maybe [DockerContainer])
+  , _hostReportSshAuthorizedKeys :: ![SshPublicKey]
+  , _hostReportSystemdServices :: ![T.Text]
+  , _hostReportSystemdTimers :: ![T.Text]
   }
   deriving (Eq, Generic, Show)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Report)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec HostReport)
 
 
-instance ADC.HasCodec Report where
+instance ADC.HasCodec HostReport where
   codec =
     _codec ADC.<?> "Host Patrol Report"
     where
       _codec =
         ADC.object "Report" $
-          Report
-            <$> ADC.requiredField "host" "Host descriptor." ADC..= _reportHost
-            <*> ADC.requiredField "cloud" "Cloud information." ADC..= _reportCloud
-            <*> ADC.requiredField "hardware" "Hardware information." ADC..= _reportHardware
-            <*> ADC.requiredField "kernel" "Kernel information." ADC..= _reportKernel
-            <*> ADC.requiredField "distribution" "Distribution information." ADC..= _reportDistribution
-            <*> ADC.requiredField "dockerContainers" "List of Docker containers if the host is a Docker host." ADC..= _reportDockerContainers
-            <*> ADC.requiredField "sshAuthorizedKeys" "List of SSH authorized keys found on host." ADC..= _reportSshAuthorizedKeys
-            <*> ADC.requiredField "systemdServices" "List of systemd services found on host." ADC..= _reportSystemdServices
-            <*> ADC.requiredField "systemdTimers" "List of systemd timers found on host." ADC..= _reportSystemdTimers
+          HostReport
+            <$> ADC.requiredField "host" "Host descriptor." ADC..= _hostReportHost
+            <*> ADC.requiredField "cloud" "Cloud information." ADC..= _hostReportCloud
+            <*> ADC.requiredField "hardware" "Hardware information." ADC..= _hostReportHardware
+            <*> ADC.requiredField "kernel" "Kernel information." ADC..= _hostReportKernel
+            <*> ADC.requiredField "distribution" "Distribution information." ADC..= _hostReportDistribution
+            <*> ADC.requiredField "dockerContainers" "List of Docker containers if the host is a Docker host." ADC..= _hostReportDockerContainers
+            <*> ADC.requiredField "sshAuthorizedKeys" "List of SSH authorized keys found on host." ADC..= _hostReportSshAuthorizedKeys
+            <*> ADC.requiredField "systemdServices" "List of systemd services found on host." ADC..= _hostReportSystemdServices
+            <*> ADC.requiredField "systemdTimers" "List of systemd timers found on host." ADC..= _hostReportSystemdTimers
 
 
 -- * Cloud Information

--- a/src/Zamazingo/Text.hs
+++ b/src/Zamazingo/Text.hs
@@ -48,3 +48,8 @@ nonempty x = Just x
 -- May throw encoding error, hence the @unsafe@.
 unsafeTextFromBL :: BL.ByteString -> T.Text
 unsafeTextFromBL = TL.toStrict . TLE.decodeUtf8
+
+
+-- | Converts a given strict text to lazy bytestring.
+blFromText :: T.Text -> BL.ByteString
+blFromText = TLE.encodeUtf8 . TL.fromStrict

--- a/src/scripts/ssh-keys.sh
+++ b/src/scripts/ssh-keys.sh
@@ -18,7 +18,7 @@ find \
     2>/dev/null |
     sort -u |
     xargs -I{} cat {} |
-    xargs -L1 echo |
+    xargs -I{} echo {} |
     grep -vE "^#" |
     sort -u |
     tr -s ' '

--- a/website/src/components/app/-data.tsx
+++ b/website/src/components/app/-data.tsx
@@ -11,146 +11,218 @@ import { Centered } from './-ui';
 export const LHP_PATROL_REPORT_SCHEMA = {
   $comment: 'Host Patrol Report\nReport',
   properties: {
-    cloud: {
-      $comment: 'Cloud information.\nCloud Information\nCloud',
-      properties: {
-        hostAvailabilityZone: { $comment: 'Host availability zone.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        hostLocalAddress: { $comment: 'Local address of the host.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        hostLocalHostname: { $comment: 'Local hostname of the host.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        hostRegion: { $comment: 'Host region.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        hostRemoteAddress: { $comment: 'Remote address of the host.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        hostRemoteHostname: { $comment: 'Remote hostname of the host.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        hostReservedAddress: {
-          $comment: 'Reserved address of the host.',
-          anyOf: [{ type: 'null' }, { type: 'string' }],
-        },
-        hostType: { $comment: 'Host type.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        id: { $comment: 'Host identifier.', anyOf: [{ type: 'null' }, { type: 'string' }] },
-        name: { $comment: 'Cloud name.', type: 'string' },
-      },
-      required: [
-        'hostReservedAddress',
-        'hostRemoteAddress',
-        'hostRemoteHostname',
-        'hostLocalAddress',
-        'hostLocalHostname',
-        'hostAvailabilityZone',
-        'hostRegion',
-        'hostType',
-        'id',
-        'name',
-      ],
-      type: 'object',
-    },
-    distribution: {
-      $comment: 'Distribution information.\nDistribution Information\nDistribution',
-      properties: {
-        codename: {
-          $comment: "Distribution codename (cat /etc/os-release | grep 'VERSION_CODENAME=').",
-          anyOf: [{ type: 'null' }, { type: 'string' }],
-        },
-        description: {
-          $comment: "Distribution description (cat /etc/os-release | grep 'PRETTY_NAME=').",
-          type: 'string',
-        },
-        id: { $comment: "Distribution ID (cat /etc/os-release | grep 'ID=').", type: 'string' },
-        name: { $comment: "Distribution name (cat /etc/os-release | grep 'NAME=')).", type: 'string' },
-        release: { $comment: "Distribution release (cat /etc/os-release | grep 'VERSION_ID=').", type: 'string' },
-        version: { $comment: "Distribution version (cat /etc/os-release | grep 'VERSION=').", type: 'string' },
-      },
-      required: ['description', 'codename', 'release', 'version', 'name', 'id'],
-      type: 'object',
-    },
-    dockerContainers: {
-      $comment: 'List of Docker containers if the host is a Docker host.',
-      anyOf: [
-        { type: 'null' },
-        {
-          items: {
-            $comment: 'Docker Container Information\nDockerContainer',
-            properties: {
-              created: { $comment: 'Date/time when the container is created at.\nLocalTime', type: 'string' },
-              id: { $comment: 'ID of the container..', type: 'string' },
-              image: { $comment: 'Image the container is created from.', type: 'string' },
-              name: { $comment: 'Name of the container.', type: 'string' },
-              running: { $comment: 'Indicates if the container is running.', type: 'boolean' },
+    hosts: {
+      $comment: 'List of host reports.',
+      items: {
+        $comment: 'Host Patrol Report\nReport',
+        properties: {
+          authorizedSshKeys: {
+            $comment: 'List of authorized SSH public keys found on host.',
+            items: {
+              $comment: 'SSH Public Key Information\nSshPublicKey',
+              properties: {
+                comment: { $comment: 'Comment on the public key.', type: 'string' },
+                data: { $comment: 'Original information.', type: 'string' },
+                fingerprint: { $comment: 'Fingerprint of the public key.', type: 'string' },
+                length: {
+                  $comment: 'Length of the public key.',
+                  maximum: 2147483647,
+                  minimum: -2147483648,
+                  type: 'number',
+                },
+                type: { $comment: 'Type of the public key.', type: 'string' },
+              },
+              required: ['fingerprint', 'comment', 'length', 'type', 'data'],
+              type: 'object',
             },
-            required: ['running', 'created', 'image', 'name', 'id'],
+            type: 'array',
+          },
+          cloud: {
+            $comment: 'Cloud information.\nCloud Information\nCloud',
+            properties: {
+              hostAvailabilityZone: {
+                $comment: 'Host availability zone.',
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              hostLocalAddress: {
+                $comment: 'Local address of the host.',
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              hostLocalHostname: {
+                $comment: 'Local hostname of the host.',
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              hostRegion: { $comment: 'Host region.', anyOf: [{ type: 'null' }, { type: 'string' }] },
+              hostRemoteAddress: {
+                $comment: 'Remote address of the host.',
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              hostRemoteHostname: {
+                $comment: 'Remote hostname of the host.',
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              hostReservedAddress: {
+                $comment: 'Reserved address of the host.',
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              hostType: { $comment: 'Host type.', anyOf: [{ type: 'null' }, { type: 'string' }] },
+              id: { $comment: 'Host identifier.', anyOf: [{ type: 'null' }, { type: 'string' }] },
+              name: { $comment: 'Cloud name.', type: 'string' },
+            },
+            required: [
+              'hostReservedAddress',
+              'hostRemoteAddress',
+              'hostRemoteHostname',
+              'hostLocalAddress',
+              'hostLocalHostname',
+              'hostAvailabilityZone',
+              'hostRegion',
+              'hostType',
+              'id',
+              'name',
+            ],
             type: 'object',
           },
-          type: 'array',
+          distribution: {
+            $comment: 'Distribution information.\nDistribution Information\nDistribution',
+            properties: {
+              codename: {
+                $comment: "Distribution codename (cat /etc/os-release | grep 'VERSION_CODENAME=').",
+                anyOf: [{ type: 'null' }, { type: 'string' }],
+              },
+              description: {
+                $comment: "Distribution description (cat /etc/os-release | grep 'PRETTY_NAME=').",
+                type: 'string',
+              },
+              id: { $comment: "Distribution ID (cat /etc/os-release | grep 'ID=').", type: 'string' },
+              name: { $comment: "Distribution name (cat /etc/os-release | grep 'NAME=')).", type: 'string' },
+              release: { $comment: "Distribution release (cat /etc/os-release | grep 'VERSION_ID=').", type: 'string' },
+              version: { $comment: "Distribution version (cat /etc/os-release | grep 'VERSION=').", type: 'string' },
+            },
+            required: ['description', 'codename', 'release', 'version', 'name', 'id'],
+            type: 'object',
+          },
+          dockerContainers: {
+            $comment: 'List of Docker containers if the host is a Docker host.',
+            anyOf: [
+              { type: 'null' },
+              {
+                items: {
+                  $comment: 'Docker Container Information\nDockerContainer',
+                  properties: {
+                    created: { $comment: 'Date/time when the container is created at.\nLocalTime', type: 'string' },
+                    id: { $comment: 'ID of the container..', type: 'string' },
+                    image: { $comment: 'Image the container is created from.', type: 'string' },
+                    name: { $comment: 'Name of the container.', type: 'string' },
+                    running: { $comment: 'Indicates if the container is running.', type: 'boolean' },
+                  },
+                  required: ['running', 'created', 'image', 'name', 'id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            ],
+          },
+          hardware: {
+            $comment: 'Hardware information.\nRudimentary Hardware Information\nHardware',
+            properties: {
+              cpuCount: {
+                $comment: 'Number of (v)CPU cores.',
+                maximum: 2147483647,
+                minimum: -2147483648,
+                type: 'number',
+              },
+              diskRoot: { $comment: 'Total disk space of root (`/`) filesystem (in GB).', type: 'number' },
+              ramTotal: { $comment: 'Total RAM (in GB).', type: 'number' },
+            },
+            required: ['diskRoot', 'ramTotal', 'cpuCount'],
+            type: 'object',
+          },
+          host: {
+            $comment: 'Host descriptor.\nHost Descriptor\nHost',
+            properties: {
+              name: { $comment: 'Name of the host.', type: 'string' },
+              tags: { $comment: 'Arbitrary tags for the host.', items: { type: 'string' }, type: 'array' },
+              url: { $comment: 'URL to external host information.', type: 'string' },
+            },
+            required: ['name'],
+            type: 'object',
+          },
+          kernel: {
+            $comment: 'Kernel information.\nKernel Information\nKernel',
+            properties: {
+              machine: { $comment: 'Architecture the kernel is running on (uname -m).', type: 'string' },
+              name: { $comment: 'Kernel name (uname -s).', type: 'string' },
+              node: { $comment: 'Name of the node kernel is running on (uname -n).', type: 'string' },
+              os: { $comment: 'Operating system the kernel is driving (uname -o).', type: 'string' },
+              release: { $comment: 'Kernel release (uname -r).', type: 'string' },
+              version: { $comment: 'Kernel version (uname -v).', type: 'string' },
+            },
+            required: ['os', 'machine', 'version', 'release', 'name', 'node'],
+            type: 'object',
+          },
+          systemdServices: {
+            $comment: 'List of systemd services found on host.',
+            items: { type: 'string' },
+            type: 'array',
+          },
+          systemdTimers: {
+            $comment: 'List of systemd timers found on host.',
+            items: { type: 'string' },
+            type: 'array',
+          },
         },
-      ],
-    },
-    hardware: {
-      $comment: 'Hardware information.\nRudimentary Hardware Information\nHardware',
-      properties: {
-        cpuCount: {
-          $comment: 'Number of (v)CPU cores.',
-          // maximum: 9223372036854775807,
-          // minimum: -9223372036854775808,
-          type: 'number',
-        },
-        diskRoot: { $comment: 'Total disk space of root (`/`) filesystem (in GB).', type: 'number' },
-        ramTotal: { $comment: 'Total RAM (in GB).', type: 'number' },
+        required: [
+          'systemdTimers',
+          'systemdServices',
+          'authorizedSshKeys',
+          'dockerContainers',
+          'distribution',
+          'kernel',
+          'hardware',
+          'cloud',
+          'host',
+        ],
+        type: 'object',
       },
-      required: ['diskRoot', 'ramTotal', 'cpuCount'],
-      type: 'object',
-    },
-    host: {
-      $comment: 'Host descriptor.\nHost Descriptor\nHost',
-      properties: {
-        name: { $comment: 'Name of the host.', type: 'string' },
-        tags: { $comment: 'Arbitrary tags for the host.', items: { type: 'string' }, type: 'array' },
-        url: { $comment: 'URL to external host information.', type: 'string' },
-      },
-      required: ['name'],
-      type: 'object',
-    },
-    kernel: {
-      $comment: 'Kernel information.\nKernel Information\nKernel',
-      properties: {
-        machine: { $comment: 'Architecture the kernel is running on (uname -m).', type: 'string' },
-        name: { $comment: 'Kernel name (uname -s).', type: 'string' },
-        node: { $comment: 'Name of the node kernel is running on (uname -n).', type: 'string' },
-        os: { $comment: 'Operating system the kernel is driving (uname -o).', type: 'string' },
-        release: { $comment: 'Kernel release (uname -r).', type: 'string' },
-        version: { $comment: 'Kernel version (uname -v).', type: 'string' },
-      },
-      required: ['os', 'machine', 'version', 'release', 'name', 'node'],
-      type: 'object',
-    },
-    sshAuthorizedKeys: {
-      $comment: 'List of SSH authorized keys found on host.',
-      items: { type: 'string' },
       type: 'array',
     },
-    systemdServices: { $comment: 'List of systemd services found on host.', items: { type: 'string' }, type: 'array' },
-    systemdTimers: { $comment: 'List of systemd timers found on host.', items: { type: 'string' }, type: 'array' },
+    knownSshKeys: {
+      $comment: 'List of known SSH public keys.',
+      items: {
+        $comment: 'SSH Public Key Information\nSshPublicKey',
+        properties: {
+          comment: { $comment: 'Comment on the public key.', type: 'string' },
+          data: { $comment: 'Original information.', type: 'string' },
+          fingerprint: { $comment: 'Fingerprint of the public key.', type: 'string' },
+          length: { $comment: 'Length of the public key.', maximum: 2147483647, minimum: -2147483648, type: 'number' },
+          type: { $comment: 'Type of the public key.', type: 'string' },
+        },
+        required: ['fingerprint', 'comment', 'length', 'type', 'data'],
+        type: 'object',
+      },
+      type: 'array',
+    },
   },
-  required: [
-    'systemdTimers',
-    'systemdServices',
-    'sshAuthorizedKeys',
-    'dockerContainers',
-    'distribution',
-    'kernel',
-    'hardware',
-    'cloud',
-    'host',
-  ],
+  required: ['knownSshKeys', 'hosts'],
   type: 'object',
 } as const satisfies JSONSchema;
 
-export type LhpData = FromSchema<typeof LHP_PATROL_REPORT_SCHEMA>;
+export type LhpPatrolReport = FromSchema<typeof LHP_PATROL_REPORT_SCHEMA>;
+
+export type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[]
+  ? ElementType
+  : never;
+
+export type LhpHostReport = ArrayElement<LhpPatrolReport['hosts']>;
 
 const AJV = new Ajv();
 
-const LHP_PATROL_REPORT_VALIDATOR = AJV.compile<LhpData>(LHP_PATROL_REPORT_SCHEMA);
+const LHP_PATROL_REPORT_VALIDATOR = AJV.compile<LhpPatrolReport>(LHP_PATROL_REPORT_SCHEMA);
 
 const _LOCAL_STORAGE_KEY_DATA = 'LHP_DATA';
 
-export function loadData(): Either<string, Maybe<LhpData[]>> {
+export function loadData(): Either<string, Maybe<LhpPatrolReport>> {
   const data = localStorage.getItem(_LOCAL_STORAGE_KEY_DATA);
 
   if (data === null) {
@@ -160,29 +232,14 @@ export function loadData(): Either<string, Maybe<LhpData[]>> {
   return parseData(data).map(Just);
 }
 
-export function saveData(x: LhpData[]): void {
-  localStorage.setItem(_LOCAL_STORAGE_KEY_DATA, JSON.stringify(x));
-}
-
-export function deleteData(): void {
-  localStorage.removeItem(_LOCAL_STORAGE_KEY_DATA);
-}
-
-export function parseData(raw: string): Either<string, LhpData[]> {
+export function parseData(data: string): Either<string, LhpPatrolReport> {
   try {
-    const parsed = JSON.parse(raw);
+    const parsed = JSON.parse(data);
+    const result = LHP_PATROL_REPORT_VALIDATOR(parsed);
 
-    if (!Array.isArray(parsed)) {
-      return Left('Data is expected to be an array of host information objects.');
-    }
-
-    for (const elem of parsed) {
-      const result = LHP_PATROL_REPORT_VALIDATOR(elem);
-
-      if (!result) {
-        console.error(elem, LHP_PATROL_REPORT_VALIDATOR.errors);
-        return Left('Invalid host information object.');
-      }
+    if (!result) {
+      console.error(LHP_PATROL_REPORT_VALIDATOR.errors);
+      return Left('Invalid lhp patrol report object.');
     }
 
     return Right(parsed);
@@ -191,7 +248,15 @@ export function parseData(raw: string): Either<string, LhpData[]> {
   }
 }
 
-export function DataLoader({ onLoadData }: { onLoadData: (x: LhpData[]) => void }) {
+export function saveData(x: LhpPatrolReport): void {
+  localStorage.setItem(_LOCAL_STORAGE_KEY_DATA, JSON.stringify(x));
+}
+
+export function deleteData(): void {
+  localStorage.removeItem(_LOCAL_STORAGE_KEY_DATA);
+}
+
+export function DataLoader({ onLoadData }: { onLoadData: (x: LhpPatrolReport) => void }) {
   const [error, setError] = useState<string>();
 
   const changeHandler = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/website/src/components/app/index.tsx
+++ b/website/src/components/app/index.tsx
@@ -3,11 +3,11 @@
 import { Just, Maybe, Nothing } from 'purify-ts/Maybe';
 import { useEffect, useState } from 'react';
 import { App } from './-app';
-import { DataLoader, LhpData, deleteData, loadData } from './-data';
+import { DataLoader, LhpPatrolReport, deleteData, loadData } from './-data';
 import { BigSpinner } from './-ui';
 
 export function AppMain() {
-  const [data, setAppData] = useState<Maybe<Maybe<LhpData[]>>>(Nothing);
+  const [data, setAppData] = useState<Maybe<Maybe<LhpPatrolReport>>>(Nothing);
 
   useEffect(() => {
     loadData().caseOf({


### PR DESCRIPTION
This also introduces "Known SSH Public Keys" information in the final report data definition.

- **fix: fix how authorized SSH public keys are streamed from host**
- **fix: change the type of CPU count**
- **feat: enrich SSH public key data definition**
- **refactor: change report format**
- **feat: add known SSH public keys**
- **refactor(website): adopt new lhp patrol report data definition**
