### PR TITLE
External ID and Extra Data Fields for Host Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ hosts:
     tags:
       - oranges
       - strawberries
+    ## Arbitrary JSON data for the host (optional)
+    data:
+      owner: Client-1
+      cost: 50
   - name: otherhost
     url: https://internal.documentation/hosts/otherhost
     tags:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ hosts:
       destination: root@10.10.10.10
       ## SSH options (optional)
       options: ["-i", "/keys/hebele.pri"]
+    ## External identifier of the host (optional)
+    id: 20b88669-743f-4ae5-9823-5aacc2df7086
     ## External URL for the host (optional)
     url: https://internal.documentation/hosts/somehost
     ## List of tags for the host (optional)

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,10 @@ hosts:
     tags:
       - oranges
       - strawberries
+    ## Arbitrary JSON data for the host (optional)
+    data:
+      owner: Client-1
+      cost: 50
   - name: otherhost
     url: https://internal.documentation/hosts/otherhost
     tags:

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,8 @@ hosts:
       destination: root@10.10.10.10
       ## SSH options (optional)
       options: ["-i", "/keys/hebele.pri"]
+    ## External identifier of the host (optional)
+    id: 20b88669-743f-4ae5-9823-5aacc2df7086
     ## External URL for the host (optional)
     url: https://internal.documentation/hosts/somehost
     ## List of tags for the host (optional)

--- a/src/Lhp/Cli.hs
+++ b/src/Lhp/Cli.hs
@@ -88,6 +88,7 @@ doCompile cpath dests par = do
         , Types._hostId = Nothing
         , Types._hostUrl = Nothing
         , Types._hostTags = []
+        , Types._hostData = Aeson.Null
         }
 
 

--- a/src/Lhp/Cli.hs
+++ b/src/Lhp/Cli.hs
@@ -81,7 +81,14 @@ doCompile cpath dests par = do
     Left err -> BLC.hPutStrLn stderr (Aeson.encode err) >> pure (ExitFailure 1)
     Right sr -> BLC.putStrLn (Aeson.encode sr) >> pure ExitSuccess
   where
-    _mkHost d = Types.Host {Types._hostName = d, Types._hostSsh = Nothing, Types._hostUrl = Nothing, Types._hostTags = []}
+    _mkHost d =
+      Types.Host
+        { Types._hostName = d
+        , Types._hostSsh = Nothing
+        , Types._hostId = Nothing
+        , Types._hostUrl = Nothing
+        , Types._hostTags = []
+        }
 
 
 -- ** schema

--- a/src/Lhp/Types.hs
+++ b/src/Lhp/Types.hs
@@ -49,6 +49,7 @@ data Host = Host
   , _hostId :: !(Maybe T.Text)
   , _hostUrl :: !(Maybe T.Text)
   , _hostTags :: ![T.Text]
+  , _hostData :: !Aeson.Value
   }
   deriving (Eq, Generic, Show)
   deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Host)
@@ -66,6 +67,7 @@ instance ADC.HasCodec Host where
             <*> ADC.optionalField "id" "External identifier of the host." ADC..= _hostId
             <*> ADC.optionalField "url" "URL to external host information." ADC..= _hostUrl
             <*> ADC.optionalFieldWithDefault "tags" [] "Arbitrary tags for the host." ADC..= _hostTags
+            <*> ADC.optionalFieldWithDefault "data" Aeson.Null "Arbitrary data for the host." ADC..= _hostData
 
 
 -- * Host Report

--- a/src/Lhp/Types.hs
+++ b/src/Lhp/Types.hs
@@ -46,6 +46,7 @@ instance ADC.HasCodec Report where
 data Host = Host
   { _hostName :: !T.Text
   , _hostSsh :: !(Maybe SshConfig)
+  , _hostId :: !(Maybe T.Text)
   , _hostUrl :: !(Maybe T.Text)
   , _hostTags :: ![T.Text]
   }
@@ -62,6 +63,7 @@ instance ADC.HasCodec Host where
           Host
             <$> ADC.requiredField "name" "Name of the host." ADC..= _hostName
             <*> ADC.optionalField "ssh" "SSH configuration." ADC..= _hostSsh
+            <*> ADC.optionalField "id" "External identifier of the host." ADC..= _hostId
             <*> ADC.optionalField "url" "URL to external host information." ADC..= _hostUrl
             <*> ADC.optionalFieldWithDefault "tags" [] "Arbitrary tags for the host." ADC..= _hostTags
 

--- a/website/src/components/report/ShowHostDetails.tsx
+++ b/website/src/components/report/ShowHostDetails.tsx
@@ -17,6 +17,16 @@ export function ShowHostDetails({ host }: { host: LhpHostReport }) {
               🔗
             </Link>
           )}
+          {host.host.id && (
+            <Chip
+              onClick={() => {
+                navigator.clipboard.writeText(host.host.id || '');
+                toast('External host identifier is copied to clipboard.');
+              }}
+            >
+              <span className="cursor-pointer">{host.host.id}</span>
+            </Chip>
+          )}
         </div>
 
         <div className="align-items flex flex-row items-center space-x-4">
@@ -139,6 +149,14 @@ export function ShowHostDetails({ host }: { host: LhpHostReport }) {
 
         <KVBox title="Systemd Timers" kvs={host.systemdTimers.map((x) => ({ key: x, value: '✅' }))} />
       </div>
+
+      <Card radius="sm" shadow="sm">
+        <CardHeader className="text-lg font-bold">Extra Host Data</CardHeader>
+
+        <CardBody>
+          <pre>{host.host.data ? JSON.stringify(host.host.data || '#N/A', null, 2) : '#N/A'}</pre>
+        </CardBody>
+      </Card>
     </div>
   );
 }

--- a/website/src/lib/data.ts
+++ b/website/src/lib/data.ts
@@ -137,6 +137,8 @@ export const LHP_PATROL_REPORT_SCHEMA = {
           host: {
             $comment: 'Host descriptor.\nHost Descriptor\nHost',
             properties: {
+              data: { $comment: 'Arbitrary data for the host.' },
+              id: { $comment: 'External identifier of the host.', type: 'string' },
               name: { $comment: 'Name of the host.', type: 'string' },
               ssh: {
                 $comment: 'SSH configuration.\nSSH Configuration\nSshConfig',


### PR DESCRIPTION
Closes #58.

- **feat: add optional external identifier to host definition**
- **feat: add optional data to host definition**
- **feat(website): adopt new host spec field on host details page**
